### PR TITLE
Fix startup dialog behavior

### DIFF
--- a/quotation_app.py
+++ b/quotation_app.py
@@ -473,8 +473,8 @@ class QuotationApp(tb.Window):
             print("Avertissement : Impossible de charger l'icône MAFCI.ico pour la fenêtre :", e)
         self.geometry("800x600")
         init_db()
-        self.ask_doc_type_and_number()
         self.create_widgets()
+        self.ask_doc_type_and_number()
 
     def ask_doc_type_and_number(self):
         import tkinter as tk
@@ -577,13 +577,17 @@ class QuotationApp(tb.Window):
     def enable_widgets(self):
         """Enable all widgets in the main window after document type and number are entered."""
         self.attributes('-disabled', False)
-        # Enable all child widgets
-        for child in self.winfo_children():
-            try:
-                if hasattr(child, 'configure') and 'state' in child.configure():
-                    child.configure(state='normal')
-            except Exception:
-                pass
+        self._set_state_recursive(self)
+
+    def _set_state_recursive(self, widget, state='normal'):
+        """Recursively set the state for widget and all of its children."""
+        try:
+            if 'state' in widget.configure():
+                widget.configure(state=state)
+        except Exception:
+            pass
+        for child in widget.winfo_children():
+            self._set_state_recursive(child, state)
 
     def setup_style(self):
         style = ttk.Style(self)


### PR DESCRIPTION
## Summary
- enable main widgets after entering bill info
- recursively unlock all nested widgets after validation
- load GUI widgets before prompting for bill data

## Testing
- `python3 -m py_compile quotation_app.py`

------
https://chatgpt.com/codex/tasks/task_e_686465aaa3cc832ba3649ca73f36dded