### PR TITLE
Align totals frame with client section

### DIFF
--- a/quotation_app.py
+++ b/quotation_app.py
@@ -966,7 +966,8 @@ class QuotationApp(tb.Window):
 
         # Auto-calculated fields
         totals_frame = ttk.LabelFrame(content_frame, text="Montants")
-        totals_frame.grid(row=2, column=0, columnspan=4, padx=15, pady=10, sticky='nsew')
+        # Align totals with the client frame for a cleaner look
+        totals_frame.grid(row=2, column=0, columnspan=2, padx=15, pady=10, sticky='nsew')
         self.ht_var = tk.StringVar(value="0.00")
         self.tva_var = tk.StringVar(value="0.00")
         self.ttc_var = tk.StringVar(value="0.00")


### PR DESCRIPTION
## Summary
- adjust totals frame to align with the client section

## Testing
- `python -m py_compile quotation_app.py pdf_viewer.py fix_client_types.py`


------
https://chatgpt.com/codex/tasks/task_e_686483af9784832b83452548c0973188